### PR TITLE
0.2.1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ "$1" == "release" ]; then
+    odin build . -show-timings -vet -o:speed
+else
+    odin build . -show-timings -debug -vet
+fi

--- a/changelog.md
+++ b/changelog.md
@@ -12,3 +12,10 @@
 - Open local `.nf` file if available. This allow to have per folder projects.
     - use `notes nl` to open the global Notes file.
 - General improvements and fixes. Check `pr 0.2` for more info.
+
+
+## 0.2.1
+
+- Linux support
+    - Fix wrong data path on linux. It requires the shell to have `$HOME` set.
+- Bug: Fix crash when it didn't had contain a file in the data directory.

--- a/errors.odin
+++ b/errors.odin
@@ -6,6 +6,7 @@ NotesError :: enum {
     FILE_NOT_FOUND,
     INVALID_VERSION,
     FAILED_TO_SAVE,
+    FAILED_TO_LOAD,
 }
 
 msg_from_err :: proc(err: NotesError) -> string {
@@ -19,6 +20,8 @@ msg_from_err :: proc(err: NotesError) -> string {
         return "Invalid version for `Notes` file. It may be corrupted."
     case .FAILED_TO_SAVE:
         return "Couldn't save the state to the working `Notes` file."
+    case .FAILED_TO_LOAD:
+        return "Couldn't load the state file."
     }
     panic("Unreachable")
 }

--- a/main.odin
+++ b/main.odin
@@ -9,7 +9,7 @@ import "core:slice"
 import "core:strconv"
 import "core:strings"
 
-NOTES_VERSION :: 0.2
+NOTES_VERSION :: "0.2.1"
 
 // :volatile(notes)
 Note :: struct {
@@ -490,7 +490,7 @@ main :: proc() {
     state: State
     err: NotesError
     if state, err = nf_load(nf_path); err != .NONE {
-        fmt.printf("[ERROR]: Failed to load {}: {}", nf_path, msg_from_err(err))
+        fmt.printfln("[ERROR]: Failed to load {}: {}", nf_path, msg_from_err(err))
         return
     }
 

--- a/nf.odin
+++ b/nf.odin
@@ -137,7 +137,10 @@ nf_check_magic_get_version_data :: proc(data: []byte) -> (int, NotesError) {
 
 nf_load :: proc(path: string) -> (State, NotesError) {
     data, ok := os.read_entire_file(path, context.temp_allocator)
-    if !ok do return {}, .FILE_NOT_FOUND
+    if !ok {
+        if os.exists(path) do return {}, .FAILED_TO_LOAD
+        return state_init(path), .NONE
+    }
 
     if version, err := nf_check_magic_get_version(data); err == .NONE do return nf_load_state_vx(path, data, version)
 

--- a/nf.odin
+++ b/nf.odin
@@ -1,6 +1,5 @@
 package main
 
-import "core:fmt"
 import "core:os"
 import "core:strings"
 /*
@@ -42,17 +41,6 @@ read_str :: proc(data: []u8, cursor: ^u32) -> string {
     len := read_u16(data, cursor)
     defer cursor^ += auto_cast len
     return strings.clone_from_bytes(data[cursor^:cursor^ + auto_cast len], context.temp_allocator)
-}
-
-nf_create_or_use_appdata_path :: proc() -> string {
-    path := os.get_env("appdata", context.temp_allocator)
-    notes_path := fmt.tprintf("{}\\notes-global", path)
-    if os.exists(notes_path) do return fmt.tprintf("{}\\global.nf", notes_path)
-
-    if err := os.make_directory(notes_path); err != nil {
-        panic("ksjdkla")
-    }
-    return fmt.tprintf("{}\\global.nf", notes_path)
 }
 
 // :volatile(proj)

--- a/nf_linux.odin
+++ b/nf_linux.odin
@@ -1,0 +1,13 @@
+#+build linux
+package main
+
+import "core:fmt"
+import "core:os"
+
+nf_create_or_use_appdata_path :: proc() -> string {
+    path: string
+    if path = os.get_env("HOME"); len(path) == 0 do fmt.panicf("$HOME not set in current shell. This is not allowed.")
+    path = fmt.tprintf("{}/.local/share/notes", path)
+    if !os.exists(path) do if err := os.make_directory(path); err != nil do fmt.panicf("Failed to create local data folder at: {}", path)
+    return fmt.tprintf("{}/global.nf", path)
+}

--- a/nf_windows.odin
+++ b/nf_windows.odin
@@ -1,0 +1,16 @@
+#+build windows
+package main
+
+import "core:fmt"
+import "core:os"
+
+nf_create_or_use_appdata_path :: proc() -> string {
+    path := os.get_env("appdata", context.temp_allocator)
+    notes_path := fmt.tprintf("{}\\notes-global", path)
+    if os.exists(notes_path) do return fmt.tprintf("{}\\global.nf", notes_path)
+
+    if err := os.make_directory(notes_path); err != nil {
+        panic("ksjdkla")
+    }
+    return fmt.tprintf("{}\\global.nf", notes_path)
+}

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,1 @@
+odin test . -out:"notes_test" -vet -define:NOTES_PATH=./test.nf -define:ODIN_TEST_THREADS=1 -define:ODIN_TEST_LOG_LEVEL="error" -define:ODIN_TEST_FANCY=false


### PR DESCRIPTION
## 0.2.1

- Linux support
    - Fix the wrong data path on Linux. It requires the shell to have `$HOME` set.
- Bug: Fix crash when it didn't contain a file in the data directory.