### PR TITLE
0.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,3 +19,16 @@
 - Linux support
     - Fix wrong data path on linux. It requires the shell to have `$HOME` set.
 - Bug: Fix crash when it didn't had contain a file in the data directory.
+
+## 0.2.2
+
+- Fix spelling and grammar in user-facing messages and docs.
+
+## 0.3
+
+- Add move command.
+    - use `mv <index> <project` to move the note with index to project.
+- Add locking system to the data file. The file is locked when the program starts and unlocked it when it ends.
+- Fix: Crash if a command was submitted with no arguments.
+- Colored output for better UX.
+- `sel <tag>` now shows the index of the note.

--- a/main.odin
+++ b/main.odin
@@ -10,7 +10,7 @@ import "core:strconv"
 import "core:strings"
 import "core:terminal/ansi"
 
-NOTES_VERSION :: "0.2.2"
+NOTES_VERSION :: "0.3"
 GREEN :: ansi.CSI + ansi.FG_GREEN + ansi.SGR
 CYAN :: ansi.CSI + ansi.FG_CYAN + ansi.SGR
 RED :: ansi.CSI + ansi.FG_RED + ansi.SGR

--- a/main.odin
+++ b/main.odin
@@ -348,12 +348,12 @@ interactive_mode :: proc(state: ^State) {
                     fmt.printfln("[{}] {}", i, n.title)
                 }
             case "sel":
-                err_expect(prompt_parts[1:], 1, "`sel` requires the tag. `sel test`.")
+                err_expect(prompt_parts[1:], 1, "`sel` requires the tag. `sel test`.", exact = true) or_break
                 sel_note(state, prompt_parts[1])
             case "rm":
                 fallthrough
             case "rn":
-                err_expect(prompt_parts[1:], 1, "`rn` requires the index of the note. use `lsi` to get it")
+                err_expect(prompt_parts[1:], 1, "`rn` requires the index of the note. use `lsi` to get it") or_break
                 rm_note(state, prompt_parts[1])
             case "sw":
                 err_expect(
@@ -361,12 +361,12 @@ interactive_mode :: proc(state: ^State) {
                     1,
                     "`sw` expects at least one argument. `sw <project name>`",
                     exact = true,
-                )
+                ) or_break
                 switch_proj(state, strings.clone(prompt_parts[1], context.temp_allocator))
             case "cp":
                 print_project(state^)
             case "del":
-                err_expect(prompt_parts[1:], 1, "`del` requires an argument. `del <project name>`")
+                err_expect(prompt_parts[1:], 1, "`del` requires an argument. `del <project name>`") or_break
                 del_proj(state, prompt_parts[1])
             case "tag":
                 err_expect(
@@ -374,7 +374,7 @@ interactive_mode :: proc(state: ^State) {
                     2,
                     "`tag` requires index of note and tag. You can get the index from `lsi` command. `tag <index> <tag>`",
                     exact = true,
-                )
+                ) or_break
                 tag_note(state, prompt_parts[1], prompt_parts[2])
             case "mv":
                 err_expect(
@@ -382,7 +382,7 @@ interactive_mode :: proc(state: ^State) {
                     2,
                     "`mv` requires index of note and the project to move into. You can get the index from `lsi` command and the project from `lsp` command. `mv <index> <project>`",
                     exact = true,
-                )
+                ) or_break
                 mv_note_to_proj(state, prompt_parts[1], prompt_parts[2])
             case "backup":
                 when ODIN_DEBUG {

--- a/main.odin
+++ b/main.odin
@@ -8,8 +8,25 @@ import "core:path/filepath"
 import "core:slice"
 import "core:strconv"
 import "core:strings"
+import "core:terminal/ansi"
 
 NOTES_VERSION :: "0.2.2"
+GREEN :: ansi.CSI + ansi.FG_GREEN + ansi.SGR
+CYAN :: ansi.CSI + ansi.FG_CYAN + ansi.SGR
+RED :: ansi.CSI + ansi.FG_RED + ansi.SGR
+RESET :: ansi.CSI + ansi.RESET + ansi.SGR
+
+s_err :: #force_inline proc() -> string {
+    return RED + "ERROR:" + RESET
+}
+
+s_suc :: #force_inline proc() -> string {
+    return GREEN + "SUCCESS:" + RESET
+}
+
+cyan :: #force_inline proc(s: string) -> string {
+    return fmt.tprintf("{}{}{}", CYAN, s, RESET)
+}
 
 // :volatile(notes)
 Note :: struct {
@@ -53,8 +70,12 @@ err_expect :: proc(parts: []string, n_args: int, msg: string, args: ..any, exact
 // :project
 add_proj :: proc(state: ^State, name: string) {
     if name in state.projs {
-        fmt.printfln("`{}` already exits.", name)
-        fmt.println("Use `sw <name>` to switch to the specified project if you aren't already on it.")
+        fmt.printfln("{} `{}` already exits.", s_err(), cyan(name))
+        fmt.printfln(
+            "{} Use `{}` to switch to the specified project if you aren't already on it.",
+            cyan("-"),
+            cyan("sw <name>"),
+        )
         return
     }
 
@@ -65,39 +86,43 @@ add_proj :: proc(state: ^State, name: string) {
     }
     state.projs[name] = p
     nf_save(state^)
+
+    fmt.printfln("{} added new project `{}`.", s_suc(), cyan(name))
 }
 
 del_proj :: proc(state: ^State, name: string) -> bool {
     if name not_in state.projs {
-        fmt.printfln("`{}` isn't a valid project name.", name)
-        fmt.println("Use `lsp` to list all projects.")
+        fmt.printfln("{} `{}` isn't a valid project name.", s_err(), cyan(name))
+        fmt.printfln("{} Use `{}` to list all projects.", cyan("-"), cyan("lsp"))
         return false
     }
 
     if state.current_proj == name do state.current_proj = ""
     delete_key(&state.projs, name)
     nf_save(state^)
+    fmt.printfln("{} deleted project `{}`.", s_suc(), cyan(name))
     return true
 }
 
 print_project :: proc(state: State) {
     if state.current_proj == "" {
-        fmt.println("No project has been created to use `cp`")
+        fmt.printfln("{} No project has been created to use `{}`", s_err(), cyan("cp"))
         return
     }
-    fmt.println("Current project:", state.current_proj)
-    fmt.println("   > N of notes:", len(state.projs[state.current_proj].notes))
+    fmt.println(CYAN + "Current project:" + RESET, state.current_proj)
+    fmt.println(CYAN + "   -" + RESET + " Number of notes:", len(state.projs[state.current_proj].notes))
 }
 
 switch_proj :: proc(state: ^State, name: string) -> bool {
     if name not_in state.projs {
-        fmt.printfln("`{}` doesn't exist.", name)
-        fmt.printfln("Use `np {}` to create the project.", name)
+        fmt.printfln("{} `{}` doesn't exist.", s_err(), cyan(name))
+        fmt.printfln("{} Use `{} {}` to create the project.", cyan("-"), cyan("np"), cyan(name))
         return false
     }
 
     state.current_proj = name
     nf_save(state^)
+    fmt.printfln("{} switched to project `{}`.", s_suc(), cyan(name))
     return true
 }
 
@@ -117,7 +142,7 @@ cpy_proj :: proc(state: ^State, old, new: string) -> Proj {
 
 rename_proj :: proc(state: ^State, old, new: string) -> bool {
     if old not_in state.projs {
-        fmt.printfln("`{}` isn't a valid project.", old)
+        fmt.printfln("{} `{}` isn't a valid project.", s_err(), cyan(old))
         return false
     }
 
@@ -127,6 +152,9 @@ rename_proj :: proc(state: ^State, old, new: string) -> bool {
     delete_key(&state.projs, old)
     state.projs[strings.clone(new, context.temp_allocator)] = cpy
     nf_save(state^)
+
+    fmt.printfln("{} renamed project `{}` -> `{}`.", s_suc(), cyan(old), cyan(new))
+
     return true
 }
 // ;project
@@ -134,34 +162,43 @@ rename_proj :: proc(state: ^State, old, new: string) -> bool {
 // :note
 add_note :: proc(state: ^State, note: string) -> bool {
     if state.current_proj == "" {
-        fmt.println("No project has been set to use `addn`")
+        fmt.printfln("{} No project has been set to use {}.", s_err(), cyan("`addn`"))
         return false
     }
     proj := &state.projs[state.current_proj]
     append(&proj.notes, Note{note, make([dynamic]string, context.temp_allocator)})
     nf_save(state^)
+    fmt.printfln("{} added new note to `{}`.", s_suc(), cyan(state.current_proj))
     return true
 }
 
 rm_note :: proc(state: ^State, idx: string) -> bool {
     if state.current_proj not_in state.projs || state.current_proj == "" {
-        fmt.eprintln("Working project not set. Use `sw` to switch to existing one or `np` to create one.")
+        fmt.printfln(
+            "{} Working project not set. Use {} to switch to existing one or {} to create one.",
+            s_err(),
+            cyan("`sw`"),
+            cyan("`np`"),
+        )
         return false
     }
 
     if len(state.projs[state.current_proj].notes) == 0 {
-        fmt.eprintln("Can remove when project doesn't contain notes")
+        fmt.printfln("{} Can't remove note when project doesn't contain notes.", s_err())
         return false
     }
 
     proj := &state.projs[state.current_proj]
     val, ok := strconv.parse_uint(idx)
     if ok && (val >= 0 && val < len(proj.notes)) {
+        note := proj.notes[val].title
+        fmt.printfln("{} removed note:", s_suc())
+        fmt.printfln("    {} {}", cyan("-"), note)
         ordered_remove(&proj.notes, val)
         nf_save(state^)
         return true
     } else {
-        fmt.println("Given argument is not a valid index.")
+        fmt.printfln("{} Given argument is not a valid index.", s_err())
         return false
     }
     panic("Unreachable")
@@ -169,12 +206,17 @@ rm_note :: proc(state: ^State, idx: string) -> bool {
 
 tag_note :: proc(state: ^State, idx, tag: string) -> bool {
     if state.current_proj not_in state.projs || state.current_proj == "" {
-        fmt.eprintln("Working project not set. Use `sw` to switch to existing one or `np` to create one.")
+        fmt.printfln(
+            "{} Working project not set. Use {} to switch to existing one or {} to create one.",
+            s_err(),
+            cyan("`sw`"),
+            cyan("`np`"),
+        )
         return false
     }
 
     if len(state.projs[state.current_proj].notes) == 0 {
-        fmt.eprintln("Can remove when project doesn't contain notes")
+        fmt.printfln("{} Can't remove tag from note when project doesn't contain notes.", s_err())
         return false
     }
 
@@ -183,14 +225,15 @@ tag_note :: proc(state: ^State, idx, tag: string) -> bool {
     if ok && (val >= 0 && val < len(proj.notes)) {
         note := &proj.notes[val]
         if _, found := slice.linear_search(note.tags[:], tag); found {
-            fmt.eprintfln("Note already contains tag: `{}`.", tag)
+            fmt.eprintfln("{} Note already contains tag: `{}`.", s_err(), cyan(tag))
             return false
         }
         append(&note.tags, strings.clone(tag, context.temp_allocator))
         nf_save(state^)
+        fmt.printfln("{} added `{}` tag to note.", s_suc(), cyan(tag))
         return true
     } else {
-        fmt.println("Given argument is not a valid index.")
+        fmt.printfln("{} Given argument is not a valid index.", s_err())
         return false
     }
     panic("Unreachable")
@@ -199,49 +242,54 @@ tag_note :: proc(state: ^State, idx, tag: string) -> bool {
 
 sel_note :: proc(state: ^State, tag: string) -> bool {
     if state.current_proj not_in state.projs || state.current_proj == "" {
-        fmt.eprintln("Working project not set. Use `sw` to switch to existing one or `np` to create one.")
+        fmt.printfln(
+            "{} Working project not set. Use {} to switch to existing one or {} to create one.",
+            s_err(),
+            cyan("`sw`"),
+            cyan("`np`"),
+        )
         return false
     }
 
     if len(state.projs[state.current_proj].notes) == 0 {
-        fmt.eprintln("Can remove when project doesn't contain notes")
+        fmt.printfln("{} Can't select notes with tag when project doesn't contain notes.", s_err())
         return false
     }
 
-    fmt.println("selected all with:", tag)
+    fmt.printfln("{}: {}", cyan("Select all notes with tag"), tag)
     for n in state.projs[state.current_proj].notes {
         if slice.contains(n.tags[:], tag) {
-            fmt.println("-", n.title)
+            fmt.printfln("{} {}", cyan("-"), n.title)
         }
     }
 
     return true
 }
 
-mv_note_to_proj :: proc(state: ^State, _index: string, proj: string) -> bool {
+mv_note_to_proj :: proc(state: ^State, _index: string, _proj: string) -> bool {
     if state.current_proj == "" {
-        fmt.println("No project has been set to use `mv`")
+        fmt.printfln("{} No project has been set to use `{}`", s_err(), cyan("mv"))
         return false
     }
 
     index, ok := strconv.parse_uint(_index)
     if !ok {
-        fmt.printfln("The given index is not a valid number: `{}`", _index)
+        fmt.printfln("{} The given index is not a valid number: `{}`", s_err(), cyan(_index))
         return false
     }
 
     if index < 0 || index >= len(state.projs[state.current_proj].notes) {
-        fmt.println("The given index is out of range.")
+        fmt.printfln("{} The given index is out of range.", s_err())
         return false
     }
 
-    if proj not_in state.projs {
-        fmt.printfln("Project `{}` isn't a valid project.", proj)
+    if _proj not_in state.projs {
+        fmt.printfln("{} Project `{}` isn't a valid project.", s_err(), cyan(_proj))
         return false
     }
 
     note := state.projs[state.current_proj].notes[index]
-    proj := &state.projs[proj]
+    proj := &state.projs[_proj]
 
     new_note := Note{}
     new_note.title = strings.clone_from(note.title, context.temp_allocator)
@@ -257,6 +305,9 @@ mv_note_to_proj :: proc(state: ^State, _index: string, proj: string) -> bool {
     }
 
     nf_save(state^)
+
+    fmt.printfln("{} moved note from `{}` -> `{}`.", s_suc(), cyan(state.current_proj), cyan(_proj))
+
     return true
 }
 
@@ -288,7 +339,7 @@ interactive_mode :: proc(state: ^State) {
 
     this: for true {
         mem.zero(raw_data(prompt), len(prompt))
-        fmt.print("> ")
+        fmt.print(GREEN + "> " + RESET)
         if libc.fgets(raw_data(prompt), auto_cast len(prompt), libc.stdin) != nil {
             prompt_size := libc.strlen(cstring(raw_data(prompt)))
             fmt.assertf(

--- a/main.odin
+++ b/main.odin
@@ -218,6 +218,48 @@ sel_note :: proc(state: ^State, tag: string) -> bool {
     return true
 }
 
+mv_note_to_proj :: proc(state: ^State, _index: string, proj: string) -> bool {
+    if state.current_proj == "" {
+        fmt.println("No project has been set to use `mv`")
+        return false
+    }
+
+    index, ok := strconv.parse_uint(_index)
+    if !ok {
+        fmt.printfln("The given index is not a valid number: `{}`", _index)
+        return false
+    }
+
+    if index < 0 || index >= len(state.projs[state.current_proj].notes) {
+        fmt.println("The given index is out of range.")
+        return false
+    }
+
+    if proj not_in state.projs {
+        fmt.printfln("Project `{}` isn't a valid project.", proj)
+        return false
+    }
+
+    note := state.projs[state.current_proj].notes[index]
+    proj := &state.projs[proj]
+
+    new_note := Note{}
+    new_note.title = strings.clone_from(note.title, context.temp_allocator)
+    new_note.tags = make([dynamic]string, context.temp_allocator)
+    for t in note.tags {
+        append(&new_note.tags, strings.clone_from(t, context.temp_allocator))
+    }
+
+    append(&proj.notes, new_note)
+
+    if !rm_note(state, _index) {
+        panic("Report bug! Couldn't remove the note after copying it to the new project")
+    }
+
+    nf_save(state^)
+    return true
+}
+
 // ;note
 
 print_help :: proc() {
@@ -238,6 +280,7 @@ print_help :: proc() {
     fmt.println("    - sel <tag>: select all with tag.")
     fmt.println("    - ls: list all notes in the current project.")
     fmt.println("    - lsi: list all notes with index in the current project.")
+    fmt.println("    - mv <index> <proj>: move note to another project.")
 }
 
 interactive_mode :: proc(state: ^State) {
@@ -333,6 +376,14 @@ interactive_mode :: proc(state: ^State) {
                     exact = true,
                 )
                 tag_note(state, prompt_parts[1], prompt_parts[2])
+            case "mv":
+                err_expect(
+                    prompt_parts[1:],
+                    2,
+                    "`mv` requires index of note and the project to move into. You can get the index from `lsi` command and the project from `lsp` command. `mv <index> <project>`",
+                    exact = true,
+                )
+                mv_note_to_proj(state, prompt_parts[1], prompt_parts[2])
             case "backup":
                 when ODIN_DEBUG {
                     copy_file :: proc(file, to: string) -> bool {

--- a/main.odin
+++ b/main.odin
@@ -9,7 +9,7 @@ import "core:slice"
 import "core:strconv"
 import "core:strings"
 
-NOTES_VERSION :: "0.2.1"
+NOTES_VERSION :: "0.2.2"
 
 // :volatile(notes)
 Note :: struct {

--- a/main.odin
+++ b/main.odin
@@ -257,9 +257,9 @@ sel_note :: proc(state: ^State, tag: string) -> bool {
     }
 
     fmt.printfln("{}: {}", cyan("Select all notes with tag"), tag)
-    for n in state.projs[state.current_proj].notes {
+    for n, idx in state.projs[state.current_proj].notes {
         if slice.contains(n.tags[:], tag) {
-            fmt.printfln("{} {}", cyan("-"), n.title)
+            fmt.printfln("{} [{}] {}", cyan("-"), idx, n.title)
         }
     }
 

--- a/main.odin
+++ b/main.odin
@@ -523,6 +523,30 @@ has_local_file :: proc() -> (string, bool) {
     return "", false
 }
 
+check_lock_file :: proc(lock_path: string = "") -> bool {
+    path := lock_path == "" ? nf_lock_path() : lock_path
+
+    if os.exists(path) {
+        return false
+    }
+
+    _, err := os.open(path, os.O_RDONLY | os.O_CREATE)
+    if err != os.ERROR_NONE {
+        fmt.println("Failed to create the .lock file")
+        return false
+    }
+
+    return true
+}
+
+remove_lock_file :: proc(lock_path: string = "") {
+    path := lock_path == "" ? nf_lock_path() : lock_path
+    if err := os.remove(path); err != os.ERROR_NONE {
+        fmt.println("Failed to remove the lock file. This will break the app when started again.")
+        fmt.printfln("Path: {}", path)
+    }
+}
+
 main :: proc() {
 
     nf_path: string
@@ -545,6 +569,11 @@ main :: proc() {
         return
     }
 
+    if !check_lock_file() {
+        fmt.println("Can't access the notes, someone has it opened.")
+        return
+    }
+
     fmt.println("working path:", nf_path)
 
     if len(os.args) == 1 || has_open {
@@ -555,8 +584,11 @@ main :: proc() {
             fmt.println("Current working project:", state.current_proj)
         }
         interactive_mode(&state)
+        remove_lock_file()
         return
     }
 
     execute_commands(&state)
+
+    remove_lock_file()
 }

--- a/nf_linux.odin
+++ b/nf_linux.odin
@@ -4,10 +4,18 @@ package main
 import "core:fmt"
 import "core:os"
 
-nf_create_or_use_appdata_path :: proc() -> string {
+nf_get_appdata_path :: proc() -> string {
     path: string
     if path = os.get_env("HOME"); len(path) == 0 do fmt.panicf("$HOME not set in current shell. This is not allowed.")
     path = fmt.tprintf("{}/.local/share/notes", path)
     if !os.exists(path) do if err := os.make_directory(path); err != nil do fmt.panicf("Failed to create local data folder at: {}", path)
-    return fmt.tprintf("{}/global.nf", path)
+    return path
+}
+
+nf_create_or_use_appdata_path :: proc() -> string {
+    return fmt.tprintf("{}/global.nf", nf_get_appdata_path())
+}
+
+nf_lock_path :: proc() -> string {
+    return fmt.tprintf("{}/.lock", nf_get_appdata_path())
 }

--- a/nf_windows.odin
+++ b/nf_windows.odin
@@ -4,7 +4,7 @@ package main
 import "core:fmt"
 import "core:os"
 
-nf_create_or_use_appdata_path :: proc() -> string {
+nf_get_appdata_path :: proc() -> string {
     path := os.get_env("appdata", context.temp_allocator)
     notes_path := fmt.tprintf("{}\\notes-global", path)
     if os.exists(notes_path) do return fmt.tprintf("{}\\global.nf", notes_path)
@@ -12,5 +12,14 @@ nf_create_or_use_appdata_path :: proc() -> string {
     if err := os.make_directory(notes_path); err != nil {
         panic("ksjdkla")
     }
-    return fmt.tprintf("{}\\global.nf", notes_path)
+
+    return path
+}
+
+nf_create_or_use_appdata_path :: proc() -> string {
+    return fmt.tprintf("{}\\global.nf", nf_get_appdata_path())
+}
+
+nf_lock_path :: proc() -> string {
+    return fmt.tprintf("{}\\.lock", nf_get_appdata_path())
 }

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ The above command performs an `add`, a `sw` and a `ls` operation in a single cli
     - [ ] edit;
     - [ ] link;
     - [ ] copy;
-    - [ ] move;
+    - [x] move;
     - [x] tags;
 - [x] Filters;
     - [x] select <tag>
@@ -47,6 +47,7 @@ The above command performs an `add`, a `sw` and a `ls` operation in a single cli
 | cp | print info about current project | - |
 | backup | create a cpy of the working file. | - |
 | tag <index> <tag> | tags the note at `index` with given `tag` | - | 
+| mv <index> <project> | moves note at `index` to `project` | - |
 | rename <old> <new> | renames project from `old` to `new` | if current project is `old` sets current project to `new` |
 | sel <tag> | list all notes with `tag` | - |
 | exit | exits the cli | - |

--- a/test.odin
+++ b/test.odin
@@ -210,3 +210,54 @@ test_save_load :: proc(t: ^T) {
     test.expect(t, ss.projs["test"].notes[0].title == "a")
     clear_test_state()
 }
+
+@(test)
+test_cmd_mv_note_to_proj :: proc(t: ^T) {
+    s := state_with_test_proj()
+    add_proj(&s, "test1")
+    test.expect(t, add_note(&s, "hello"), "failed to add note")
+    test.expect(t, tag_note(&s, "0", "a"), "failed to tag note")
+    test.expectf(t, s.current_proj == "test1", "expected `test1` is `{}`", s.current_proj)
+    test.expect(t, mv_note_to_proj(&s, "0", "test"), "failed to mv note")
+    test.expect(t, len(s.projs[s.current_proj].notes) == 0, "test1 shouldn't contain any notes")
+    test.expect(t, len(s.projs["test"].notes) == 1, "test should contain the note moved")
+    test.expectf(
+        t,
+        s.projs["test"].notes[0].title == "hello",
+        "test should contain the note `hello` but has `{}`",
+        s.projs["test"].notes[0].title,
+    )
+    test.expect(t, len(s.projs["test"].notes[0].tags) == 1, "The moved note should contain one tag")
+    test.expectf(
+        t,
+        s.projs["test"].notes[0].tags[0] == "a",
+        "The moved note should contain tag `a` but has `{}`",
+        s.projs["test"].notes[0].tags[0],
+    )
+    clear_test_state()
+}
+
+@(test)
+test_cmd_mv_note_fail_invalid_index :: proc(t: ^T) {
+    s := state_with_test_proj()
+    test.expect(t, !mv_note_to_proj(&s, "a", ""), "Should fail when a number isnt provided!")
+    clear_test_state()
+}
+
+@(test)
+test_cmd_mv_note_fail_index_out_of_range :: proc(t: ^T) {
+    s := state_with_test_proj()
+    test.expect(t, add_note(&s, "a"), "failed to add note")
+    test.expect(t, !mv_note_to_proj(&s, "2", ""), "Should fail since the project only contains one note")
+
+    clear_test_state()
+}
+
+@(test)
+test_cmd_mv_note_fail_invalid_proj :: proc(t: ^T) {
+    s := state_with_test_proj()
+    test.expect(t, add_note(&s, "a"), "failed to add note")
+    test.expect(t, !mv_note_to_proj(&s, "0", "test1"), "Should fail since the project is invalid")
+
+    clear_test_state()
+}

--- a/test.odin
+++ b/test.odin
@@ -7,8 +7,10 @@ import test "core:testing"
 T :: test.T
 
 NOTES_PATH :: #config(NOTES_PATH, "")
+LOCK_PATH :: #config(LOCK_PATH, "")
 
 state_with_test_proj :: proc() -> State {
+    check_lock_file(LOCK_PATH)
     s := state_init(NOTES_PATH)
     add_proj(&s, "test")
     nf_save(s)
@@ -16,9 +18,10 @@ state_with_test_proj :: proc() -> State {
 }
 
 clear_test_state :: proc() {
-    if os.exists("./test.bin") {
-        os.remove("./test.bin")
+    if os.exists("./test.nf") {
+        os.remove("./test.nf")
     }
+    remove_lock_file()
 }
 
 @(test)
@@ -60,7 +63,7 @@ test_cmd_del_not_current_project :: proc(t: ^T) {
 
 @(test)
 test_cmd_del_fail_not_valid_name :: proc(t: ^T) {
-    state := state_init()
+    state := state_with_test_proj()
     test.expect(t, !del_proj(&state, "slkda"), "del should fail when deleting invalid project")
     clear_test_state()
 }
@@ -84,8 +87,9 @@ test_cmd_rename :: proc(t: ^T) {
 
 @(test)
 test_cmd_rename_fail_invalid_proj :: proc(t: ^T) {
-    state := state_init()
+    state := state_with_test_proj()
     test.expect(t, !rename_proj(&state, "a", "b"), "rename should fail on invalid project")
+    clear_test_state()
 }
 
 @(test)
@@ -120,7 +124,8 @@ test_cmd_sw_fail_invalid :: proc(t: ^T) {
 
 @(test)
 test_cmd_add_note_fail_no_project :: proc(t: ^T) {
-    state := state_init()
+    check_lock_file()
+    state := state_init(NOTES_PATH)
     test.expectf(t, !add_note(&state, "test"), "`addn` should fail when the current proj isn't set")
     clear_test_state()
 }
@@ -140,7 +145,7 @@ test_cmd_add_note :: proc(t: ^T) {
 
 @(test)
 test_cmd_rm_note_fail_no_project :: proc(t: ^T) {
-    state := state_init()
+    state := state_with_test_proj()
     test.expect(t, !rm_note(&state, "0"), "`rn` should fail when the current_proj isnt set")
     clear_test_state()
 }


### PR DESCRIPTION
## 0.3

- Add move command.
    - use `mv <index> <project` to move the note with index to project.
- Add locking system to the data file. The file is locked when the program starts and unlocked it when it ends.
- Fix: Crash if a command was submitted with no arguments.
- Colored output for better UX.
- `sel <tag>` now shows the index of the note.